### PR TITLE
Fix Typo

### DIFF
--- a/src/main/java/com/couricraft/CouriCraft.java
+++ b/src/main/java/com/couricraft/CouriCraft.java
@@ -113,7 +113,7 @@ public final class CouriCraft extends JavaPlugin implements Listener, EventListe
         } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException ex) {}
     }
 
-    public void handleeEvent(GuildMessageReceivedEvent event) {
+    public void handleEvent(GuildMessageReceivedEvent event) {
         if (event.isWebhookMessage() || event.getAuthor().isSystem() || event.getAuthor().isBot()) return;
         if (event.getChannel().getId().contentEquals(config.getString("channels.whitelist"))) {
             Player player = getServer().getPlayerExact(event.getMessage().getContentRaw());


### PR DESCRIPTION
`handleEvent()` had an extra e in it (it was `handleeEvent`)